### PR TITLE
Optional Whetstone Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ This module overwrites the styling (CSS) of the official 5e sheet that comes wit
 
 You can select the Dark sheet per Actor.
 
+### Whetstone Compatible
+
+If Whestone is active, the Foundry-Wide Dark Mode setting will be dropped in favor of allowing Whetstone to manage the theme's activation. Darkmode Character sheets can be selected even without activating the Whetstone theme.
+
 ## Changelog:
+
+Update v2.2.0
+* Integrates with Whetstone optionally
+______________
 
 Update v2.1.2
 * Fixed Compatibility issues with Foundry 0.7.5

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -1,22 +1,3 @@
-:root {
-	--5edark-rgb-text-blue: #3F88E6;
-	--5edark-rgb-text-blue-2: #7bb4ff;
-	--5edark-rgb-text-white: #b5b5b5;
-	--5edark-rgb-text-white-2: #b5b5b5;
-	--5edark-rgb-text-white-3: #d8d8d8;
-
-	--5edark-rgb-border-grey: #444444;
-	--5edark-rgb-border-grey--alt: #505050;
-	--5edark-rgb-border-blue: #5177ab;
-
-	--5edark-rgb-bg-black: #191919;
-	--5edark-rgb-bg-black--alt: #292929;
-
-	--5edark-rgb-scroll-blue: #0C3A75;
-
-	--5edark-rgb-active-blue: #004aa9;
-}
-
 .dark-mode a:hover,
 .dark-mode .filepicker li:hover {
 	color: var(--5edark-rgb-text-blue-2);

--- a/dnd5edark.css
+++ b/dnd5edark.css
@@ -1,3 +1,22 @@
+:root {
+	--5edark-rgb-text-blue: #3F88E6;
+	--5edark-rgb-text-blue-2: #7bb4ff;
+	--5edark-rgb-text-white: #b5b5b5;
+	--5edark-rgb-text-white-2: #b5b5b5;
+	--5edark-rgb-text-white-3: #d8d8d8;
+
+	--5edark-rgb-border-grey: #444444;
+	--5edark-rgb-border-grey--alt: #505050;
+	--5edark-rgb-border-blue: #5177ab;
+
+	--5edark-rgb-bg-black: #191919;
+	--5edark-rgb-bg-black--alt: #292929;
+
+	--5edark-rgb-scroll-blue: #0C3A75;
+
+	--5edark-rgb-active-blue: #004aa9;
+}
+
 .dnd5edark.sheet a:hover {
 	color: var(--5edark-rgb-text-blue) !important;
 	text-shadow: 0 0 4px var(--5edark-rgb-text-blue);

--- a/dnd5edark.js
+++ b/dnd5edark.js
@@ -2,8 +2,10 @@ import ActorSheet5eCharacter from "../../systems/dnd5e/module/actor/sheets/chara
 import ActorSheet5eNPC from "../../systems/dnd5e/module/actor/sheets/npc.js";
 import ItemSheet5e from "../../systems/dnd5e/module/item/sheet.js";
 
+const cssClassName = 'dark-mode'; // The css class used
+
 class ActorSheet5eCharacterDark extends ActorSheet5eCharacter {
-	static get defaultOptions () {
+	static get defaultOptions() {
 		const options = super.defaultOptions;
 		options.classes.push('dnd5edark'); // this is the css class selector to apply the dark theme to
 		return options;
@@ -11,7 +13,7 @@ class ActorSheet5eCharacterDark extends ActorSheet5eCharacter {
 }
 
 class ActorSheet5eNPCDark extends ActorSheet5eNPC {
-	static get defaultOptions () {
+	static get defaultOptions() {
 		const options = super.defaultOptions;
 		options.classes.push('dnd5edark'); // this is the css class selector to apply the dark theme to
 		return options;
@@ -19,14 +21,14 @@ class ActorSheet5eNPCDark extends ActorSheet5eNPC {
 }
 
 class ItemSheet5eDark extends ItemSheet5e {
-	static get defaultOptions () {
+	static get defaultOptions() {
 		const options = super.defaultOptions;
 		options.classes.push('dnd5edark'); // this is the css class selector to apply the dark theme to
 		return options;
 	}
 }
 
-async function registerBetterNpcDark () {
+async function registerBetterNpcDark() {
 	const module = game.modules.get("betternpcsheet5e");
 	// only continue if the module is existent and activated
 	if (!module || !module.active)
@@ -37,7 +39,7 @@ async function registerBetterNpcDark () {
 
 	// Define your custom class
 	class BetterNPCActor5eSheetDark extends BetterNPCActor5eSheet {
-		static get defaultOptions () {
+		static get defaultOptions() {
 			const options = super.defaultOptions;
 			options.classes.push('betternpcsheet-dark'); // this is the css class selector to apply the dark theme to
 			return options;
@@ -67,9 +69,17 @@ Items.registerSheet("dnd5e", ItemSheet5eDark, {
 });
 
 Hooks.on('init', () => {
+
+	console.log('dnd5edark init', {
+		isWhetstoneActive: game.modules.get('Whetstone').active
+	});
+
 	registerBetterNpcDark();
 
-	const cssClassName = 'dark-mode'; // The css class used
+	if (!!game.modules.get('Whetstone')?.active) {
+		return;
+	}
+
 	game.settings.register("dnd5e-dark-mode", game.userId, {
 		name: "Activate Foundry wide Dark Mode?", // Change for description
 		// hint: "Hint?" // uncomment this line for a small description text/hint
@@ -88,4 +98,60 @@ Hooks.on('init', () => {
 	const setDarkMode = game.settings.get('dnd5e-dark-mode', game.userId);
 	if (setDarkMode === true)
 		document.body.classList.add(cssClassName);
+});
+
+Hooks.once('WhetstoneReady', () => {
+	game.Whetstone.themes.register('dnd5e-dark-mode', {
+		id: 'DarkMode',
+		name: 'DarkMode',
+		title: 'Dark Mode',
+		description: 'A foundry-wide dark mode specifically tuned towards dnd5e compatibility.',
+		version: '2.1.2',
+		authors: [
+			{
+				name: 'Stryxin',
+				contact: 'Github',
+				url: 'https://github.com/Stryxin'
+			}
+		],
+		variables: [
+		],
+		styles: [
+			"modules/dnd5e-dark-mode/dark-mode.css"
+		],
+		presets: {
+		},
+		dialog: '',
+		config: '',
+		dependencies: {},
+		systems: { core: '0.6.6' },
+		compatible: {},
+		conflicts: {}
+	});
+
+
+	game.Whetstone.settings.registerMenu('DarkMode', 'DarkMode', {
+		name: game.i18n.localize('WHETSTONE.Config'),
+		label: game.i18n.localize('WHETSTONE.ConfigTitle'),
+		hint: game.i18n.localize('WHETSTONE.ConfigHint'),
+		icon: 'fas fa-paint-brush',
+		restricted: false
+	});
+});
+
+Hooks.on('onThemeActivate', (themeData) => {
+	console.log('onThemeActivate', {
+		themeData
+	})
+	if (themeData.id === 'DarkMode') {
+		document.body.classList.add(cssClassName);
+	}
+
+	return true
+});
+
+Hooks.on('onThemeDeactivate', (themeData) => {
+	if (themeData.id === 'DarkMode' && document.body.classList.contains(cssClassName)) {
+		document.body.classList.remove(cssClassName);
+	}
 });

--- a/dnd5edark.js
+++ b/dnd5edark.js
@@ -5,7 +5,7 @@ import ItemSheet5e from "../../systems/dnd5e/module/item/sheet.js";
 const cssClassName = 'dark-mode'; // The css class used
 
 class ActorSheet5eCharacterDark extends ActorSheet5eCharacter {
-	static get defaultOptions() {
+	static get defaultOptions () {
 		const options = super.defaultOptions;
 		options.classes.push('dnd5edark'); // this is the css class selector to apply the dark theme to
 		return options;
@@ -13,7 +13,7 @@ class ActorSheet5eCharacterDark extends ActorSheet5eCharacter {
 }
 
 class ActorSheet5eNPCDark extends ActorSheet5eNPC {
-	static get defaultOptions() {
+	static get defaultOptions () {
 		const options = super.defaultOptions;
 		options.classes.push('dnd5edark'); // this is the css class selector to apply the dark theme to
 		return options;
@@ -21,7 +21,7 @@ class ActorSheet5eNPCDark extends ActorSheet5eNPC {
 }
 
 class ItemSheet5eDark extends ItemSheet5e {
-	static get defaultOptions() {
+	static get defaultOptions () {
 		const options = super.defaultOptions;
 		options.classes.push('dnd5edark'); // this is the css class selector to apply the dark theme to
 		return options;
@@ -39,7 +39,7 @@ async function registerBetterNpcDark() {
 
 	// Define your custom class
 	class BetterNPCActor5eSheetDark extends BetterNPCActor5eSheet {
-		static get defaultOptions() {
+		static get defaultOptions () {
 			const options = super.defaultOptions;
 			options.classes.push('betternpcsheet-dark'); // this is the css class selector to apply the dark theme to
 			return options;
@@ -69,13 +69,9 @@ Items.registerSheet("dnd5e", ItemSheet5eDark, {
 });
 
 Hooks.on('init', () => {
-
-	console.log('dnd5edark init', {
-		isWhetstoneActive: game.modules.get('Whetstone').active
-	});
-
 	registerBetterNpcDark();
 
+	// If Whetstone is active, stop here
 	if (!!game.modules.get('Whetstone')?.active) {
 		return;
 	}
@@ -127,7 +123,7 @@ Hooks.once('WhetstoneReady', () => {
 		config: '',
 		dependencies: {},
 		systems: { core: '0.6.6' },
-		compatible: {},
+		compatible: { dnd5e: '0.9.8' },
 		conflicts: {}
 	});
 
@@ -142,9 +138,6 @@ Hooks.once('WhetstoneReady', () => {
 });
 
 Hooks.on('onThemeActivate', (themeData) => {
-	console.log('onThemeActivate', {
-		themeData
-	})
 	if (themeData.id === 'DarkMode') {
 		document.body.classList.add(cssClassName);
 	}

--- a/dnd5edark.js
+++ b/dnd5edark.js
@@ -80,6 +80,8 @@ Hooks.on('init', () => {
 		return;
 	}
 
+	$(`<link href="/modules/dnd5e-dark-mode/dnd5edark.css" rel="stylesheet" type="text/css" media="all">`).appendTo($('head'));
+
 	game.settings.register("dnd5e-dark-mode", game.userId, {
 		name: "Activate Foundry wide Dark Mode?", // Change for description
 		// hint: "Hint?" // uncomment this line for a small description text/hint

--- a/module.json
+++ b/module.json
@@ -10,8 +10,7 @@
 	"scripts": [],
 	"styles": [
 		"dnd5edark.css",
-		"betternpcsheet-dark.css",
-		"dark-mode.css"
+		"betternpcsheet-dark.css"
 	],
 	"esmodules": [
 		"dnd5edark.js"

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "dnd5e-dark-mode",
 	"title": "D&D5E Dark Mode",
 	"description": "A dark sheet style for the default D&D5E character and NPC sheets.",
-	"version": "2.1.2",
+	"version": "2.2.0",
 	"author": "Stryxin",
 	"systems": [
 		"dnd5e"


### PR DESCRIPTION
First steps towards integration with [Whetstone](https://github.com/MajorVictory/Whetstone).

Changes:
- Remove `dark-mode.css` from module.json as we want Whetstone to load this if necessary. If Whetstone is not active on `init`, we add this ourselves to the `head`.
- Register a "Dark Mode" theme for Whetstone which basically does nothing but apply `dark-mode.css`. Next steps could be to allow variable overrides (e.g. highlight color changes).
